### PR TITLE
chore(pHash): based on imagededup algorithm

### DIFF
--- a/hashcompute.go
+++ b/hashcompute.go
@@ -85,23 +85,25 @@ func PerceptionHash(img image.Image) (*ImageHash, error) {
 	return phash, nil
 }
 
-// PerceptionHash32 function returns a hash computation of phash.
+// PerceptionHashImageDedup function returns a hash computation of phash.
 // Implementation follows
 // http://www.hackerfactor.com/blog/index.php?/archives/432-Looks-Like-It.html
-func PerceptionHash32(img image.Image) (*ImageHash, error) {
+// Based on imagededup Jpeg result
+// https://github.com/idealo/imagededup
+func PerceptionHashImageDedup(img image.Image) (*ImageHash, error) {
 	if img == nil {
 		return nil, errors.New("Image object can not be nil")
 	}
 
 	phash := NewImageHash(0, PHash)
-	resized := resize.Resize(32, 32, img, resize.Bilinear)
+	resized := resize.Resize(64, 64, img, resize.Lanczos3)
 	pixels := transforms.Rgb2Gray(resized)
-	dct := transforms.DCT2D(pixels, 32, 32)
+	dct := transforms.DCT2D(pixels, 64, 64)
 	flattens := transforms.FlattenPixels(dct, 8, 8)
-	median := etcs.MedianOfPixels(flattens)
+	median := etcs.MedianOfPixels(flattens[1:])
 
 	for idx, p := range flattens {
-		if p > median {
+		if p >= median {
 			phash.leftShiftSet(len(flattens) - idx - 1)
 		}
 	}


### PR DESCRIPTION
- [x] Add median of coefficients excluding the DC term (0th term) 
- [x] Add greater equals to include the median pixel as well.

Tests based on [dog.jpg](https://images.wagwalkingweb.com/media/articles/care/why-is-my-dog-holding-his-tail-down/why-is-my-dog-holding-his-tail-down.jpg)

+ goimagehash `PerceptionHash()`
0xf9cfe6c8c72180d2
1111100111001111111001101100100011000111001000011**0000000**11010010

+ imagededup `phash()`
0xf9cfe6c8c72188d2
1111100111001111111001101100100011000111001000011**0001000**11010010

+ goimagehash `PerceptionHashImageDedup()`
0xf9cfe6c8c72188d2
1111100111001111111001101100100011000111001000011**0001000**11010010
